### PR TITLE
Fix/ql fieldset styling caption text

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -120,7 +120,7 @@ const AddItem = ({ token, results }) => {
             className={classes.formControlLabel}
           />
           <Typography className={classes.caption} variant="caption">
-            More than 7 days, less than 14 days
+            More than 14 days, less than 30 days
           </Typography>
           <Divider />
         </RadioGroup>


### PR DESCRIPTION
## Description

Fixes caption text for the "Not Soon" option

## Related Issue

#47 

## Acceptance Criteria

N/A

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓  | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="370" alt="Screen Shot 2020-09-20 at 11 23 00 AM" src="https://user-images.githubusercontent.com/25488451/93714885-a77b4900-fb33-11ea-80bc-d312d73b75c8.png">

### After

<img width="383" alt="Screen Shot 2020-09-20 at 11 21 35 AM" src="https://user-images.githubusercontent.com/25488451/93714869-77cc4100-fb33-11ea-8840-5b11fe1d3396.png">


## Testing Steps / QA Criteria

- Make sure the "Not Soon" caption text reads, "More than 14 days, less than 30 days".

