### PR TITLE
Ql input styling

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -9,6 +9,7 @@ import {
   Typography,
   Divider,
   Box,
+  TextField,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
@@ -61,14 +62,14 @@ const AddItem = ({ token, results }) => {
   return (
     <form onSubmit={event => handleSubmitForm(event)}>
       <Box>
-        <Box>
-          <label htmlFor="add-shopping-list-item">Item Name</label>
-        </Box>
-        <input
+        <Typography component="h1">Smart Shopping List</Typography>
+        <TextField
           required
-          value={name}
-          onChange={e => setName(e.target.value)}
           id="add-shopping-list-item"
+          variant="outlined"
+          label="Item Name"
+          onChange={e => setName(e.target.value)}
+          value={name}
         />
       </Box>
       <FormControl component="fieldset">

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -62,7 +62,9 @@ const AddItem = ({ token, results }) => {
   return (
     <form onSubmit={event => handleSubmitForm(event)}>
       <Box>
-        <Typography component="h1">Smart Shopping List</Typography>
+        <header>
+          <Typography variant="h4">Smart Shopping List</Typography>
+        </header>
         <TextField
           required
           id="add-shopping-list-item"

--- a/src/components/ClearIconButton.js
+++ b/src/components/ClearIconButton.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import ClearIcon from '@material-ui/icons/Clear';
+import { IconButton } from '@material-ui/core';
+import { withStyles } from '@material-ui/core/styles';
+
+const ClearIconButton = p => {
+  return (
+    <IconButton {...p}>
+      <ClearIcon />
+    </IconButton>
+  );
+};
+
+export const NoPaddingClearIcon = withStyles({
+  root: {
+    padding: 0,
+  },
+})(props => ClearIconButton(props));

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -20,6 +20,7 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
 import SearchIcon from '@material-ui/icons/Search';
+import ClearIcon from '@material-ui/icons/Clear';
 
 const DecoratedCheckbox = p => {
   return (
@@ -195,6 +196,18 @@ You cannot undo this action, and this item's purchase history will be lost.`,
     }
   }
 
+  const getEndSearchIcon = () => {
+    if (searchTerm === '') {
+      return <SearchIcon />;
+    } else {
+      return (
+        <IconButton onClick={() => setSearchTerm('')}>
+          <ClearIcon />
+        </IconButton>
+      );
+    }
+  };
+
   return (
     <div className={styles['list-container']}>
       <header>
@@ -221,17 +234,11 @@ You cannot undo this action, and this item's purchase history will be lost.`,
             InputProps={{
               endAdornment: (
                 <InputAdornment position="end">
-                  <SearchIcon />
+                  {getEndSearchIcon()}
                 </InputAdornment>
               ),
             }}
           />
-          <button
-            disabled={searchTerm === ''}
-            onClick={() => setSearchTerm('')}
-          >
-            x
-          </button>
         </div>
       )}
       <div className={styles['list-results-container']}>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import styles from '../List.module.css';
 import Details from './Details';
 import { updatePurchaseDate, deleteItem } from '../lib/firebase.js';
-import { withStyles, makeStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/core/styles';
 import { green, orange, red, grey } from '@material-ui/core/colors';
 import {
   FormControlLabel,
@@ -20,13 +20,8 @@ import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
 import SearchIcon from '@material-ui/icons/Search';
-import ClearIcon from '@material-ui/icons/Clear';
+import { NoPaddingClearIcon } from './ClearIconButton.js';
 
-const useStyles = makeStyles({
-  clearButton: {
-    padding: 0,
-  },
-});
 const DecoratedCheckbox = p => {
   return (
     <Checkbox
@@ -80,8 +75,6 @@ const GreyCheckbox = withStyles({
 
 const List = ({ results, setSearchTerm, searchTerm, token }) => {
   const [details, setDetails] = useState({});
-
-  const classes = useStyles();
 
   function handleOnCheck(event, purchaseDates) {
     updatePurchaseDate(token, event.target.value, purchaseDates);
@@ -207,14 +200,7 @@ You cannot undo this action, and this item's purchase history will be lost.`,
     if (searchTerm === '') {
       return <SearchIcon />;
     } else {
-      return (
-        <IconButton
-          className={classes.clearButton}
-          onClick={() => setSearchTerm('')}
-        >
-          <ClearIcon />
-        </IconButton>
-      );
+      return <NoPaddingClearIcon onClick={() => setSearchTerm('')} />;
     }
   };
 

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -11,12 +11,15 @@ import {
   IconButton,
   Grid,
   Paper,
+  TextField,
   Typography,
+  InputAdornment,
 } from '@material-ui/core';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
+import SearchIcon from '@material-ui/icons/Search';
 
 const DecoratedCheckbox = p => {
   return (
@@ -209,18 +212,20 @@ You cannot undo this action, and this item's purchase history will be lost.`,
         </>
       ) : (
         <div>
-          <div>
-            <label htmlFor="searchField" className="sr-only">
-              Search
-            </label>
-          </div>
-          <input
+          <TextField
+            variant="outlined"
+            label="Search"
+            id="search-field"
             onChange={event => setSearchTerm(event.target.value)}
-            autoFocus
             value={searchTerm}
-            id="searchField"
-            placeholder="Search..."
-          ></input>
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <SearchIcon />
+                </InputAdornment>
+              ),
+            }}
+          />
           <button
             disabled={searchTerm === ''}
             onClick={() => setSearchTerm('')}

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import styles from '../List.module.css';
 import Details from './Details';
 import { updatePurchaseDate, deleteItem } from '../lib/firebase.js';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
 import { green, orange, red, grey } from '@material-ui/core/colors';
 import {
   FormControlLabel,
@@ -22,6 +22,11 @@ import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
 import SearchIcon from '@material-ui/icons/Search';
 import ClearIcon from '@material-ui/icons/Clear';
 
+const useStyles = makeStyles({
+  clearButton: {
+    padding: 0,
+  },
+});
 const DecoratedCheckbox = p => {
   return (
     <Checkbox
@@ -75,6 +80,8 @@ const GreyCheckbox = withStyles({
 
 const List = ({ results, setSearchTerm, searchTerm, token }) => {
   const [details, setDetails] = useState({});
+
+  const classes = useStyles();
 
   function handleOnCheck(event, purchaseDates) {
     updatePurchaseDate(token, event.target.value, purchaseDates);
@@ -201,7 +208,10 @@ You cannot undo this action, and this item's purchase history will be lost.`,
       return <SearchIcon />;
     } else {
       return (
-        <IconButton onClick={() => setSearchTerm('')}>
+        <IconButton
+          className={classes.clearButton}
+          onClick={() => setSearchTerm('')}
+        >
           <ClearIcon />
         </IconButton>
       );

--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import getToken from '../lib/tokens';
 import { writeToFirestore, db } from '../lib/firebase';
+import { TextField } from '@material-ui/core';
+import { NoPaddingClearIcon } from './ClearIconButton.js';
 
 const Welcome = ({ setToken }) => {
   const [input, setInput] = useState('');
@@ -39,10 +41,16 @@ const Welcome = ({ setToken }) => {
         <div>
           <label htmlFor="join-list">Enter a share token</label>
         </div>
-        <input
+        <TextField
+          label="Enter Token"
+          variant="outlined"
           id="join-list"
           onChange={event => setInput(event.target.value)}
-        ></input>
+          value={input}
+          InputProps={{
+            endAdornment: <NoPaddingClearIcon onClick={() => setInput('')} />,
+          }}
+        ></TextField>
         <button type="submit">Submit</button>
       </form>
     </div>


### PR DESCRIPTION
## Description

### What does this code change? 

- Update input styling from plain CSS to Material UI
- Create new Material UI TextField components for `AddItem.js`, `List.js` and `Welcome.js`
- Add header and Typography element to `AddItem.js` to match the same elements in `List.js`
- Create a `NoPaddingClearIcon` component to abstract any `TextField` which has an `InputProps` prop with an `endAdornment` of Material UI's `ClearIcon`.

### Why did I choose this approach?

At this stage in the project I did not think it would make sense to create a new wrapper for the TextField Material UI component. The TextField component does a great job of abstracting the creation of an html input element with a label element 


## Related Issue

Closes #40 

## Acceptance Criteria

- Convert html label and input elements to use Material UI

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|   | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |
|  ✓  | :sparkles: Styling update

## Updates

### Before

#### AddItem.js

<img width="374" alt="Screen Shot 2020-09-21 at 11 53 24 AM" src="https://user-images.githubusercontent.com/25488451/93790462-12df1c80-fc01-11ea-93f5-611f8e681d56.png">

#### List.js

<img width="338" alt="Screen Shot 2020-09-21 at 11 54 03 AM" src="https://user-images.githubusercontent.com/25488451/93790545-2ab6a080-fc01-11ea-8a0d-cc9dfafe651e.png">

#### Welcome.js

<img width="785" alt="Screen Shot 2020-09-22 at 1 20 25 PM" src="https://user-images.githubusercontent.com/25488451/93915703-67a09700-fcd6-11ea-8978-06355a78283d.png">


### After


#### AddItem.js

<img width="445" alt="Screen Shot 2020-09-21 at 11 50 17 AM" src="https://user-images.githubusercontent.com/25488451/93790088-a2380000-fc00-11ea-8c90-39139cb6d14f.png">

#### List.js

<img width="349" alt="Screen Shot 2020-09-21 at 11 51 02 AM" src="https://user-images.githubusercontent.com/25488451/93790168-bb40b100-fc00-11ea-8f01-756575cea44f.png">

#### Welcome.js

<img width="806" alt="Screen Shot 2020-09-22 at 1 19 57 PM" src="https://user-images.githubusercontent.com/25488451/93915643-522b6d00-fcd6-11ea-9324-d2c5a87215b2.png">




## Testing Steps / QA Criteria

- TextFields are still controlled
- TextFields are of the "outlined" variant
- Adding items functionality remains the same - (AddItem.js)
- Search functionality remains the same - (List.js)