### PR TITLE
Ql button styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -86,7 +86,8 @@ ul {
   background-color: white;
   border-radius: 10px;
   padding: 20px;
-  position: relative;
+  display: flex;
+  flex-direction: column;
 }
 
 .back-button {

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -139,7 +139,7 @@ const AddItem = ({ token, results }) => {
           variant="contained"
           color="secondary"
         >
-          Add To List
+          <Typography>Add To List</Typography>
         </Button>
       </Box>
     </form>

--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -9,6 +9,7 @@ import {
   Typography,
   Divider,
   Box,
+  Button,
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import { grey } from '@material-ui/core/colors';
@@ -21,6 +22,10 @@ const useStyles = makeStyles({
   formControlLabel: {
     justifyContent: 'space-between',
     margin: 0,
+  },
+  button: {
+    borderRadius: '25px',
+    color: 'white',
   },
 });
 
@@ -126,9 +131,16 @@ const AddItem = ({ token, results }) => {
         </RadioGroup>
       </FormControl>
       <Box>
-        <button type="submit" onClick={() => setName(name.trim())}>
-          Add Item
-        </button>
+        <Button
+          type="submit"
+          onClick={() => setName(name.trim())}
+          className={classes.button}
+          size="large"
+          variant="contained"
+          color="secondary"
+        >
+          Add To List
+        </Button>
       </Box>
     </form>
   );

--- a/src/components/Details.js
+++ b/src/components/Details.js
@@ -1,6 +1,18 @@
 import React from 'react';
+import ChevronLeftRoundedIcon from '@material-ui/icons/ChevronLeftRounded';
+import IconButton from '@material-ui/core/IconButton';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  button: {
+    color: 'black',
+    alignSelf: 'start',
+  },
+});
 
 const Details = ({ details, setDetails }) => {
+  const classes = useStyles();
+
   const numOfPurch = details.purchaseDates.length;
   const lastPurch = numOfPurch
     ? Math.max(...details.purchaseDates)
@@ -35,14 +47,16 @@ const Details = ({ details, setDetails }) => {
   return (
     <div className="background">
       <div className="modal">
+        <IconButton
+          aria-label="back to list"
+          onClick={() => setDetails({})}
+          color="secondary"
+          className={classes.button}
+          size="medium"
+        >
+          <ChevronLeftRoundedIcon />
+        </IconButton>
         <div className="details-header">
-          <button
-            className="back-button"
-            aria-label="back to list"
-            onClick={() => setDetails({})}
-          >
-            <span role="img">&#60;</span>
-          </button>
           <h2>Smart Shopping List</h2>
         </div>
         <h3>{details.name}</h3>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -18,6 +18,7 @@ import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
+import CloseIcon from '@material-ui/icons/Close';
 
 const DecoratedCheckbox = p => {
   return (
@@ -223,12 +224,13 @@ You cannot undo this action, and this item's purchase history will be lost.`,
             placeholder="Search..."
           ></input>
           <Button
+            size="small"
             color="secondary"
             variant="contained"
             disabled={searchTerm === ''}
             onClick={() => setSearchTerm('')}
           >
-            X
+            <CloseIcon fontSize="small" />
           </Button>
         </div>
       )}

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -12,13 +12,11 @@ import {
   Grid,
   Paper,
   Typography,
-  Button,
 } from '@material-ui/core';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
 import CircleUnchecked from '@material-ui/icons/RadioButtonUnchecked';
 import CircleCheckedFilled from '@material-ui/icons/CheckCircle';
-import CloseIcon from '@material-ui/icons/Close';
 
 const DecoratedCheckbox = p => {
   return (
@@ -223,15 +221,6 @@ You cannot undo this action, and this item's purchase history will be lost.`,
             id="searchField"
             placeholder="Search..."
           ></input>
-          <Button
-            size="small"
-            color="secondary"
-            variant="contained"
-            disabled={searchTerm === ''}
-            onClick={() => setSearchTerm('')}
-          >
-            <CloseIcon fontSize="small" />
-          </Button>
         </div>
       )}
       <div className={styles['list-results-container']}>

--- a/src/components/List.js
+++ b/src/components/List.js
@@ -12,6 +12,7 @@ import {
   Grid,
   Paper,
   Typography,
+  Button,
 } from '@material-ui/core';
 import MoreHorizIcon from '@material-ui/icons/MoreHoriz';
 import DeleteOutlineIcon from '@material-ui/icons/DeleteOutline';
@@ -221,12 +222,14 @@ You cannot undo this action, and this item's purchase history will be lost.`,
             id="searchField"
             placeholder="Search..."
           ></input>
-          <button
+          <Button
+            color="secondary"
+            variant="contained"
             disabled={searchTerm === ''}
             onClick={() => setSearchTerm('')}
           >
-            x
-          </button>
+            X
+          </Button>
         </div>
       )}
       <div className={styles['list-results-container']}>

--- a/src/components/Welcome.js
+++ b/src/components/Welcome.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import getToken from '../lib/tokens';
 import { writeToFirestore, db } from '../lib/firebase';
+import { Button } from '@material-ui/core';
 
 const Welcome = ({ setToken }) => {
   const [input, setInput] = useState('');
@@ -30,9 +31,15 @@ const Welcome = ({ setToken }) => {
   return (
     <div>
       <h1>Welcome to your Smart Shopping list!</h1>
-      <Link to="/list" onClick={setTokenStorage}>
+      <Button
+        component={Link}
+        variant="contained"
+        color="secondary"
+        to="/list"
+        onClick={setTokenStorage}
+      >
         Create New List
-      </Link>
+      </Button>
       <p>- or -</p>
       <p>Join an existing shopping list by entering a three word token.</p>
       <form onSubmit={handleSubmit}>
@@ -43,7 +50,9 @@ const Welcome = ({ setToken }) => {
           id="join-list"
           onChange={event => setInput(event.target.value)}
         ></input>
-        <button type="submit">Submit</button>
+        <Button variant="contained" color="secondary" type="submit">
+          Submit
+        </Button>
       </form>
     </div>
   );


### PR DESCRIPTION
## Description

#### What does this code change? 

- Add styling for `List.js` clear input button
- Add styling for `AddItem.js` "Add To List" button
- Add styling for `Details.js` go back button
- Add styling for `Welcome.js` token submit button and 'Create New List' Material UI `Button` as `react-router-dom` `Link`

#### Why did I choose this approach? 

I wanted to provide base styles for the buttons without dealing with full page layout as that can be organized when all new styling is done. That also means that I provided a `color="secondary"` prop to all of the buttons to immediately load our default button theme as the secondary color when we finish the theme.


## Related Issue

Closes #43 

## Acceptance Criteria

- Add styling to all button components that are not related to the List items in `List.js` to match [current Figma design](https://www.figma.com/file/MMUP1esyOfgOGX39UoXk8u/TCL---Group-10?node-id=0%3A1)

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |
|  ✓  | :sparkles: Styling update

## Updates

### Before

#### AddItem.js

<img width="372" alt="Screen Shot 2020-09-21 at 9 26 32 PM" src="https://user-images.githubusercontent.com/25488451/93836539-2023f780-fc51-11ea-8801-29a442fa93fb.png">

#### Details.js

<img width="586" alt="Screen Shot 2020-09-21 at 9 27 29 PM" src="https://user-images.githubusercontent.com/25488451/93836594-421d7a00-fc51-11ea-8943-af9ee6a310f1.png">

#### List.js

##### Disabled

<img width="346" alt="Screen Shot 2020-09-21 at 9 27 59 PM" src="https://user-images.githubusercontent.com/25488451/93836620-5497b380-fc51-11ea-8778-8ad492026439.png">

##### Enabled

<img width="329" alt="Screen Shot 2020-09-21 at 9 28 12 PM" src="https://user-images.githubusercontent.com/25488451/93836627-5b262b00-fc51-11ea-8674-52da808a903c.png">

#### Welcome.js

<img width="785" alt="Screen Shot 2020-09-22 at 1 20 25 PM" src="https://user-images.githubusercontent.com/25488451/93915703-67a09700-fcd6-11ea-8978-06355a78283d.png">


### After

#### AddItem.js

<img width="368" alt="Screen Shot 2020-09-21 at 9 24 22 PM" src="https://user-images.githubusercontent.com/25488451/93836453-d5a27b00-fc50-11ea-9dcb-312cdd375939.png">

#### Details.js

<img width="720" alt="Screen Shot 2020-09-21 at 9 25 08 PM" src="https://user-images.githubusercontent.com/25488451/93836482-ee129580-fc50-11ea-901a-235720a9c66b.png">

#### List.js

##### Disabled

<img width="333" alt="Screen Shot 2020-09-21 at 9 25 40 PM" src="https://user-images.githubusercontent.com/25488451/93836497-01256580-fc51-11ea-80c1-08e4fc6017e2.png">

##### Enabled

<img width="334" alt="Screen Shot 2020-09-21 at 9 25 58 PM" src="https://user-images.githubusercontent.com/25488451/93836509-0b476400-fc51-11ea-8ab5-320344a4fd37.png">

#### Welcome.js

<img width="833" alt="Screen Shot 2020-09-22 at 1 26 44 PM" src="https://user-images.githubusercontent.com/25488451/93916281-48563980-fcd7-11ea-93cf-b81afe7670fe.png">

## Testing Steps / QA Criteria

- `List.js` clear input button should be disabled when the input is empty and appear when input is not empty
- `AddItem.js` "Add To List" button should submit the form, allowing a user to create a new item with `addedDate, frequency, name, and purchaseDate` fields. 
- `Details.js` back button should allow a user to exit the `Details.js` modal and return to the `List.js` page
- All button elements in project should use Material UI components
- `Welcome.js` 'Create New List' button should be a Material UI `Button` component acting as a `react-router-dom` `Link` component
- `Welcome.js` submit button should submit the token entered in the accompanying input
