### PR TITLE
Adjust styles to fit all app content within viewport

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,18 +2,41 @@ import React, { useState, useEffect } from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
 import { db } from './lib/firebase.js';
 import './App.css';
+import { Box } from '@material-ui/core';
 import Welcome from './components/Welcome';
 import List from './components/List';
 import AddItem from './components/AddItem';
 import BottomNav from './components/BottomNav';
 import TopNav from './components/TopNav';
 import RequireAuth from './components/RequireAuth';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles({
+  appContainer: {
+    display: 'flex',
+    flexFlow: 'column',
+    height: '100%',
+    background: '#fff',
+  },
+  topNav: {
+    flex: '0 1 auto',
+  },
+  mainContent: {
+    flex: '1 1 auto',
+    padding: '20px',
+  },
+  bottomNav: {
+    flex: '0 1 auto',
+  },
+});
 
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token'));
   const [isLoading, setIsLoading] = useState(true);
   let [results, setResults] = useState([]);
   const [searchTerm, setSearchTerm] = useState('');
+
+  const classes = useStyles();
 
   useEffect(() => {
     let unsubscribe;
@@ -42,10 +65,10 @@ function App() {
   }, [token]);
 
   return (
-    <div className="App">
-      <div style={{ background: '#fff', borderRadius: 5 }}>
-        <TopNav token={token} setToken={setToken} />
-        <div style={{ padding: '20px' }}>
+    <Box className="App">
+      <Box className={classes.appContainer}>
+        <TopNav className={classes.topNav} token={token} setToken={setToken} />
+        <Box className={classes.mainContent}>
           <Switch>
             <Route
               exact
@@ -83,10 +106,14 @@ function App() {
             </RequireAuth>
             <Redirect to="/" />
           </Switch>
-        </div>
-      </div>
-      {token ? <BottomNav /> : null}
-    </div>
+        </Box>
+        {token ? (
+          <Box className={classes.bottomNav}>
+            <BottomNav />
+          </Box>
+        ) : null}
+      </Box>
+    </Box>
   );
 }
 

--- a/src/components/BottomNav.js
+++ b/src/components/BottomNav.js
@@ -1,23 +1,12 @@
 import React from 'react';
-
 import { Link } from 'react-router-dom';
-import { makeStyles } from '@material-ui/core/styles';
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import FormatListBulletedIcon from '@material-ui/icons/FormatListBulleted';
 import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 
-const useStyles = makeStyles(theme => ({
-  root: {
-    minWidth: 375,
-    maxWidth: 3000,
-    height: 30,
-  },
-}));
-
 export default function FullWidthTabs() {
-  const classes = useStyles();
   const [value, setValue] = React.useState(0);
 
   const handleChange = (event, newValue) => {
@@ -25,7 +14,7 @@ export default function FullWidthTabs() {
   };
 
   return (
-    <div className={classes.root}>
+    <div>
       <AppBar position="static" color="default">
         <Tabs
           value={value}


### PR DESCRIPTION
## Description

- Use Material UI makeStyles to layout app styles for app container, the main content of the app, and each navbar. 
- Add Box components to place each section positionally

## Related Issue

N/A

## Acceptance Criteria

- Any element inside of the App should not overflow past the Box with a class "App-container"

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|   ✓  | :bug: Bug fix              |
|    | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<img width="562" alt="Screen Shot 2020-09-25 at 1 17 36 PM" src="https://user-images.githubusercontent.com/25488451/94344227-ca05da00-ffeb-11ea-96bd-ceef95b78566.png">

<img width="455" alt="Screen Shot 2020-09-26 at 11 32 44 AM" src="https://user-images.githubusercontent.com/25488451/94344263-0cc7b200-ffec-11ea-86a2-3a5d246c3d85.png">


### After

<img width="455" alt="Screen Shot 2020-09-26 at 11 33 39 AM" src="https://user-images.githubusercontent.com/25488451/94344279-236e0900-ffec-11ea-9322-ebcd7c691c11.png">

<img width="455" alt="Screen Shot 2020-09-26 at 11 30 02 AM" src="https://user-images.githubusercontent.com/25488451/94344194-a04cb300-ffeb-11ea-8e62-09184abb69b3.png">

## Testing Steps / QA Criteria

- Make sure entire app fits within the Box with className="App" without any elements overflowing

